### PR TITLE
Address some errors/warnings compiling in C++ mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,13 @@ CFLAGS = -Werror=implicit     \
         -Werror=incompatible-pointer-types \
         -Werror=int-to-pointer-cast        \
         -fsanitize=address
+INCLUDES = -I$(SRCDIR)/include
+SRCDIR = $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+VPATH := $(VPATH) $(SRCDIR)
+BUILDDIR := $(PWD)/bin
 
 .PHONY: all
 all: $(CFILES)
-	@ mkdir -p bin
-	gcc $(CFLAGS) -Iinclude $^ -o bin/kesscc
+	@ mkdir -p $(BUILDDIR)
+	echo [CC] $^ - $@
+	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $(BUILDDIR)/kesscc

--- a/include/ast.h
+++ b/include/ast.h
@@ -5,7 +5,8 @@
 #include <token.h>
 
 typedef enum {
-  AST_ADD,
+  AST_NONE = -1,
+  AST_ADD = 0,
   AST_SUB,
   AST_MUL,
   AST_DIV,

--- a/src/ast.c
+++ b/src/ast.c
@@ -9,7 +9,7 @@ static uint64_t nodes_idx = 0;
 
 struct ASTNode* mkastnode(AST_OP op, struct ASTNode* left, struct ASTNode* mid, struct ASTNode* right, uint64_t intval) {
   if (nodes == NULL) {
-    nodes = malloc(sizeof(struct ASTNode*));
+    nodes = (struct ASTNode**) malloc(sizeof(struct ASTNode*));
     if (nodes == NULL) {
       fclose(input);
       printf(ERR "__INTERNAL_ERR__ [Unable to malloc() node list in %s]\n", __FILE__);
@@ -17,7 +17,7 @@ struct ASTNode* mkastnode(AST_OP op, struct ASTNode* left, struct ASTNode* mid, 
     }
   }
 
-  struct ASTNode* n = malloc(sizeof(struct ASTNode));
+  struct ASTNode* n = (struct ASTNode*)  malloc(sizeof(struct ASTNode));
 
   if (n == NULL) {
       fclose(input);
@@ -31,7 +31,7 @@ struct ASTNode* mkastnode(AST_OP op, struct ASTNode* left, struct ASTNode* mid, 
   n->intval = intval;
   n->mid = mid;
 
-  nodes = realloc(nodes, sizeof(struct ASTNode*) * (nodes_idx + 2));
+  nodes = (struct ASTNode**) realloc(nodes, sizeof(struct ASTNode*) * (nodes_idx + 2));
   
   if (nodes == NULL) {
       fclose(input);
@@ -87,5 +87,7 @@ AST_OP arithop(TOKEN_TYPE tok_type) {
       return AST_LE;
     case TT_GE:
       return AST_GT;
+    default:
+      return AST_NONE;
   }
 }

--- a/src/compile.c
+++ b/src/compile.c
@@ -18,8 +18,8 @@
 
 extern struct SymbolTable globsyms[MAX_SYMBOLS];
 static FILE* out = NULL;
-static char* regs[MAX_USED_REGS] = {"%r8", "%r9", "%r10", "%r11"};
-static char* bregs[MAX_USED_REGS] = {"%r8b", "%r9b", "%r10b", "%r11b"};
+static const char* regs[MAX_USED_REGS] = {"%r8", "%r9", "%r10", "%r11"};
+static const char* bregs[MAX_USED_REGS] = {"%r8b", "%r9b", "%r10b", "%r11b"};
 static uint8_t reg_bitmap = 0b1111;
 static char out_name[150];
 
@@ -211,8 +211,8 @@ static uint64_t alloc_label(void) {
 
 REG mkAST(struct ASTNode* tree, REG r, AST_OP parent_op);
 
-static char *cmplist[] = {"sete", "setne", "setl", "setg", "setle", "setge"};
-static char *invcmplist[] = {"jne", "je", "jge", "jle", "jg", "jl"};
+static const char *cmplist[] = {"sete", "setne", "setl", "setg", "setle", "setge"};
+static const char *invcmplist[] = {"jne", "je", "jge", "jle", "jg", "jl"};
 
 REG rcmpnset(AST_OP op, REG r1, REG r2) {
   if (op < AST_EQ || op > AST_GE) {
@@ -357,6 +357,8 @@ REG mkAST(struct ASTNode* node, REG r, AST_OP parent_op) {
     case AST_OUT:
       rprintint(leftreg);
       freeall_regs();
+      return -1;
+    default:
       return -1;
   }
 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -38,8 +38,9 @@ static char next(void) {
 
 static int scanint(char c) {
   int k, val = 0;
+  char numbers[] = "0123456789";
 
-  while ((k = chrpos("0123456789", c)) >= 0) {
+  while ((k = chrpos(numbers, c)) >= 0) {
     val = val * 10 + k;
     c = next();
   }
@@ -84,6 +85,8 @@ static TOKEN_TYPE keyword(const char* what) {
     return TT_ELSE;
   } else if (strcmp(what, "while") == 0) {
     return TT_WHILE;
+  } else {
+    return (TOKEN_TYPE)-1;
   }
 }
 
@@ -173,7 +176,7 @@ uint8_t scan(struct Token* tok) {
         fclose(input);
         exit(1);
       }
-    case EOF:
+    case (char)EOF:
       tok->type = TT_EOF;
       tok->ch = '\0';
       return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,7 @@
 
 FILE* input = NULL;
 
-COMPILE_FLAGS compile_flags = 0;
+COMPILE_FLAGS compile_flags = (COMPILE_FLAGS)0;
 
 static void run(void) {
   parse();
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
       switch (argv[i][1]) {
         case 's':
           // Output only asm.
-          compile_flags |= CF_ASMONLY;
+          compile_flags = (COMPILE_FLAGS)(compile_flags | CF_ASMONLY);
           break;
       }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -38,7 +38,7 @@ static struct ASTNode* primary(void) {
 }
 
 
-static void tok_assert(TOKEN_TYPE tt, char* what) {
+static void tok_assert(TOKEN_TYPE tt, const char* what) {
   if (cur_token.type == tt) {
     scan(&cur_token);
   } else {
@@ -223,7 +223,7 @@ static struct ASTNode* statement(void) {
         tree = var_dec();
 
         if (tree != NULL) {
-          mkAST(tree, -1, 0);
+          mkAST(tree, -1, AST_ADD);
           freeall_regs();
         }
 
@@ -236,7 +236,7 @@ static struct ASTNode* statement(void) {
         break;
       case TT_ID:
         tree = assignment(0);
-        mkAST(tree, -1, 0);
+        mkAST(tree, -1, AST_ADD);
         freeall_regs();
         break;
       case TT_WHILE:
@@ -264,6 +264,6 @@ static struct ASTNode* statement(void) {
 void parse(void) {
   scan(&cur_token);
   compile_init();
-  mkAST(statement(), -1, 0);
+  mkAST(statement(), -1, AST_ADD);
   compile_end();
 }


### PR DESCRIPTION
- Adjust makefile to support building out of tree
- Allow overriding CC, INCLUDES
- Squash some type safety/void return from non-void/switch exhaustiveness/{m,c,re}alloc type casts